### PR TITLE
add BaseEnv, a related test, and fix a minor bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,17 +60,14 @@ using Transducers
 using Test
 
 
-struct SubEnv2 <: AbstractEnv
-    initial_state
-end
-struct Env1 <: AbstractEnv
-end
+# `BaseEnv` is a kind of syntax sugar for definition of environment; provided by `src/zoo.jl`.
+# Note: `NestedEnvironments.initial_condition(env::BaseEnv) = env.initial_state`
 struct Env2 <: AbstractEnv
-    env21::SubEnv2
-    env22::SubEnv2
+    env21::BaseEnv
+    env22::BaseEnv
 end
 struct Env <: AbstractEnv
-    env1::Env1
+    env1::BaseEnv
     env2::Env2
     gain::Float64
 end
@@ -89,13 +86,10 @@ function dynamics(env::Env)
     end
 end
 
-# if you extend `NestedEnvironments.initial_condition` for all sub environments, then `NestedEnvironments.initial_condition(env::Env)` will automatically complete a nested initial condition as NamedTuple.
-NestedEnvironments.initial_condition(env::SubEnv2) = env.initial_state
-NestedEnvironments.initial_condition(env::Env1) = -1  # scalar system
 # for convenience
 function make_env()
-    env21, env22 = SubEnv2(reshape(1:8, 2, 4)), SubEnv2(reshape(9:16, 2, 4))
-    env1 = Env1()
+    env21, env22 = BaseEnv(reshape(collect(1:8), 2, 4)), BaseEnv(reshape(collect(9:16), 2, 4))
+    env1 = BaseEnv(-1)
     env2 = Env2(env21, env22)
     gain = 2.0
     env = Env(env1, env2, gain)
@@ -109,6 +103,8 @@ __x0 = NestedEnvironments.initial_condition(__env)
 # test
 function test()
     env = make_env()
+    # initial condition
+    # if you extend `NestedEnvironments.initial_condition` for all sub environments, then `NestedEnvironments.initial_condition(env::Env)` will automatically complete a readable initial condition as NamedTuple.
     x0 = NestedEnvironments.initial_condition(env)  # auto-completion of initial condition
     @show x0  # x0 = (env1 = -1, env2 = (env21 = [1 3 5 7; 2 4 6 8], env22 = [9 11 13 15; 10 12 14 16]))
     t0 = 0.0

--- a/src/APIs.jl
+++ b/src/APIs.jl
@@ -88,7 +88,7 @@ A macro that transforms a readable (NamedTuple) value to raw (flattened array) v
 """
 macro raw(x)
     ex = quote
-        local env_x_cands = zip(NestedEnvironments.__REGISTERED_ENVS.__envs, NestedEnvironments.__REGISTERED_ENVS.__xs) |> Filter(env_x -> size(env_x[2]) == size($(x))) |> collect
+        local env_x_cands = zip(NestedEnvironments.__REGISTERED_ENVS.__envs, NestedEnvironments.__REGISTERED_ENVS.__xs) |> Transducers.Filter(env_x -> size(env_x[2]) == size($(x))) |> collect
         if length(env_x_cands) == 0
             error("There is no matched registered envrionment")
         elseif length(env_x_cands) > 1
@@ -124,7 +124,7 @@ A macro that transforms a raw (flattened array) value to readable (NamedTuple) v
 """
 macro readable(_x)
     ex = quote
-        local env_x_cands = zip(NestedEnvironments.__REGISTERED_ENVS.__envs, NestedEnvironments.__REGISTERED_ENVS.__xs) |> Filter(env_x -> NestedEnvironments.flatten_length(env_x[2]) == NestedEnvironments.flatten_length($(_x))) |> collect
+        local env_x_cands = zip(NestedEnvironments.__REGISTERED_ENVS.__envs, NestedEnvironments.__REGISTERED_ENVS.__xs) |> Transducers.Filter(env_x -> NestedEnvironments.flatten_length(env_x[2]) == NestedEnvironments.flatten_length($(_x))) |> collect
         if length(env_x_cands) == 0
             error("There is no matched registered envrionment")
         elseif length(env_x_cands) > 1

--- a/src/NestedEnvironments.jl
+++ b/src/NestedEnvironments.jl
@@ -6,7 +6,7 @@ using Transducers
 export AbstractEnv  # types.jl
 # internalAPIs.jl
 export raw, readable, @reg_env, @raw, @readable  # APIs.jl
-# zoo.jl
+export BaseEnv, InputAffineQuadraticCostEnv  # zoo.jl
 
 
 include("types.jl")

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,3 +1,4 @@
+## basic
 # envs
 abstract type AbstractEnv end
 
@@ -11,3 +12,6 @@ __REGISTERED_ENVS = RegisteredEnvs([], [])
 # generic functions
 function readable end
 function raw end
+
+
+## zoo

--- a/src/zoo.jl
+++ b/src/zoo.jl
@@ -2,6 +2,18 @@ using LinearAlgebra
 using Parameters
 
 
+########## Base Env ##########
+# BaseEnv
+struct BaseEnv <: AbstractEnv
+    initial_state
+end
+BaseEnv(given_size::Tuple) = BaseEnv(zeros(given_size))
+BaseEnv(args...) = BaseEnv(zeros(args...))
+BaseEnv() = BaseEnv(0.0)
+# initial_condition
+NestedEnvironments.initial_condition(env::BaseEnv) = env.initial_state
+
+
 ########## InputAffineQuadraticCostEnv ##########
 """
 An example of continuous-time nonlinear dynamical system introduced in

--- a/test/irl.jl
+++ b/test/irl.jl
@@ -1,0 +1,8 @@
+using NestedEnvironments
+using DifferentialEquations
+
+
+struct IntegralRLEnv <: AbstractEnv
+    env::InputAffineQuadraticCostEnv
+    ∫r::IntegralRLEnv
+end

--- a/test/nested_envs.jl
+++ b/test/nested_envs.jl
@@ -4,17 +4,14 @@ using Transducers
 using Test
 
 
-struct SubEnv2 <: AbstractEnv
-    initial_state
-end
-struct Env1 <: AbstractEnv
-end
+# `BaseEnv` is a kind of syntax sugar for definition of environment; provided by `src/zoo.jl`.
+# Note: `NestedEnvironments.initial_condition(env::BaseEnv) = env.initial_state`
 struct Env2 <: AbstractEnv
-    env21::SubEnv2
-    env22::SubEnv2
+    env21::BaseEnv
+    env22::BaseEnv
 end
 struct Env <: AbstractEnv
-    env1::Env1
+    env1::BaseEnv
     env2::Env2
     gain::Float64
 end
@@ -33,13 +30,10 @@ function dynamics(env::Env)
     end
 end
 
-# if you extend `NestedEnvironments.initial_condition` for all sub environments, then `NestedEnvironments.initial_condition(env::Env)` will automatically complete a nested initial condition as NamedTuple.
-NestedEnvironments.initial_condition(env::SubEnv2) = env.initial_state
-NestedEnvironments.initial_condition(env::Env1) = -1  # scalar system
 # for convenience
 function make_env()
-    env21, env22 = SubEnv2(reshape(collect(1:8), 2, 4)), SubEnv2(reshape(collect(9:16), 2, 4))
-    env1 = Env1()
+    env21, env22 = BaseEnv(reshape(collect(1:8), 2, 4)), BaseEnv(reshape(collect(9:16), 2, 4))
+    env1 = BaseEnv(-1)
     env2 = Env2(env21, env22)
     gain = 2.0
     env = Env(env1, env2, gain)
@@ -53,6 +47,8 @@ __x0 = NestedEnvironments.initial_condition(__env)
 # test
 function test()
     env = make_env()
+    # initial condition
+    # if you extend `NestedEnvironments.initial_condition` for all sub environments, then `NestedEnvironments.initial_condition(env::Env)` will automatically complete a readable initial condition as NamedTuple.
     x0 = NestedEnvironments.initial_condition(env)  # auto-completion of initial condition
     @show x0  # x0 = (env1 = -1, env2 = (env21 = [1 3 5 7; 2 4 6 8], env22 = [9 11 13 15; 10 12 14 16]))
     t0 = 0.0

--- a/test/nested_envs.jl
+++ b/test/nested_envs.jl
@@ -38,7 +38,7 @@ NestedEnvironments.initial_condition(env::SubEnv2) = env.initial_state
 NestedEnvironments.initial_condition(env::Env1) = -1  # scalar system
 # for convenience
 function make_env()
-    env21, env22 = SubEnv2(reshape(1:8, 2, 4)), SubEnv2(reshape(9:16, 2, 4))
+    env21, env22 = SubEnv2(reshape(collect(1:8), 2, 4)), SubEnv2(reshape(collect(9:16), 2, 4))
     env1 = Env1()
     env2 = Env2(env21, env22)
     gain = 2.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,10 +35,7 @@ __x0 = initial_condition(__env)
 function test1()
     env = Env(SubSubEnv(), SubEnv(SubSubEnv(), SubSubEnv()))
     x0 = initial_condition(env)
-    # @show names(env)
-    # @show size(env)
-    _x0 = @show NestedEnvironments.raw(env, x0)
-    @show NestedEnvironments.readable(env, _x0)
+    @test x0 == @readable(@raw(x0))
 end
 
 function test2()
@@ -46,8 +43,6 @@ function test2()
     x0 = initial_condition(env)
     _x0 = @raw env x0
     x0_new = @readable env _x0
-    @show x0
-    @show x0_new
     @test x0 == x0_new
 end
 
@@ -59,9 +54,26 @@ function test3()
     tspan = (t0, tf)
     ts = t0:0.01:tf
     prob = ODEProblem(env, f, x0, tspan)
-    @time sol = solve(prob, Tsit5(), saveat=ts)
+    sol = solve(prob, Tsit5(), saveat=ts)
     @test sol.u[1] == @raw env x0
 end
-test1()
-test2()
-test3()
+
+function test4()
+    env1 = BaseEnv()
+    @test NestedEnvironments.initial_condition(env1) == 0.0
+    size_tuple = (1, 2)
+    env2 = BaseEnv(size_tuple)
+    @test NestedEnvironments.initial_condition(env2) == zeros(size_tuple)
+    env3 = BaseEnv(size_tuple...)
+    @test NestedEnvironments.initial_condition(env3) == zeros(size_tuple)
+    x0 = reshape(collect(1:15), 3, 5)
+    env4 = BaseEnv(x0)
+    @test NestedEnvironments.initial_condition(env4) == x0
+end
+
+function test()
+    test1()
+    test2()
+    test3()
+    test4()
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,7 +35,7 @@ __x0 = initial_condition(__env)
 function test1()
     env = Env(SubSubEnv(), SubEnv(SubSubEnv(), SubSubEnv()))
     x0 = initial_condition(env)
-    @test x0 == @readable(@raw(x0))
+    @test x0 == @readable @raw x0
 end
 
 function test2()


### PR DESCRIPTION
# Changes
## New environment
### BaseEnv
`BaseEnv` is a structure with a field `initial_state`.
`NestedEnvironments.initial_condition(env::BaseEnv) = env.initial_state` as default.

## New test
See `test/runtests.jl`.

## Fix a minor bug
A bug of macros is fixed.